### PR TITLE
feat(dns): add Babo Violent and Mainguy preview records

### DIFF
--- a/roles/dns/defaults/main.yml
+++ b/roles/dns/defaults/main.yml
@@ -18,6 +18,7 @@ dns_zones:
   - soh.re
   - rightwaypropertycare.com
   - ahhc.org
+  - baboviolent.net
   - augustine.care
   - harborvane.io
   - harborvane.com

--- a/roles/dns/files/zones/baboviolent.net
+++ b/roles/dns/files/zones/baboviolent.net
@@ -1,0 +1,22 @@
+; BIND db file for baboviolent.net
+
+$TTL 3600
+$ORIGIN baboviolent.net.
+
+@       IN      SOA     ns1.vpsaddict.com. jon.soh.re. (
+                        2026081901      ; serial number YYYYMMDDnn
+                        14400           ; Refresh
+                        3600            ; Retry
+                        1209600         ; Expire
+                        3600            ; Min TTL
+                        )
+
+@               IN      NS      ns1.vpsaddict.com.
+@               IN      NS      ns2.vpsaddict.com.
+@               IN      NS      ns3.vpsaddict.com.
+@               IN      A       68.183.148.253
+@               IN      AAAA    2604:a880:800:14::2fda:a000
+www             IN      CNAME   homelab.soh.re.
+play            IN      CNAME   homelab.soh.re.
+relay           IN      CNAME   homelab.soh.re.
+server          IN      CNAME   homelab.soh.re.

--- a/roles/dns/files/zones/standouthost.com
+++ b/roles/dns/files/zones/standouthost.com
@@ -4,7 +4,7 @@ $TTL 3600
 $ORIGIN standouthost.com.
 
 @       IN      SOA     ns1.vpsaddict.com.        jon.standouthost.com. (
-                        2026081211      ; serial number YYYYMMDDnn
+                        2026081212      ; serial number YYYYMMDDnn
                         14400           ; Refresh
                         3600            ; Retry
                         1209600         ; Expire
@@ -26,4 +26,5 @@ www             IN      CNAME   homelab.soh.re.
 zot             IN      CNAME   homelab.soh.re.
 kanban          IN      CNAME   homelab.soh.re.
 mainguy.com.preview IN  CNAME   homelab.soh.re.
+mainguy.com.v2.preview IN CNAME   homelab.soh.re.
 zmail._domainkey IN	TXT "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0/4ia1N2XVfTw7emk6dqbjvIatRK3RipuYGQ56obm0ueYRDOxnnvRp/i0/UCYvdY6dDGhI4CGpKoGg7C1mxCZRv6yGHirxCm2rAFo3rT0Z0yR+aVLF6WcUUW4Efb+XUVbWRYxrCSP/4BBfIEauab2Lgcq0sI1/9vLhDt0NkBYYwIDAQAB"


### PR DESCRIPTION
Adds the authoritative baboviolent.net zone for the website, browser client, relay, and game server. Also includes the existing Mainguy v2 preview DNS record from this branch.